### PR TITLE
fix(jmx): remove reference to Permanent memory settings

### DIFF
--- a/md/how_to_enable_remote_monitoring_jmx.md
+++ b/md/how_to_enable_remote_monitoring_jmx.md
@@ -12,8 +12,6 @@ bonita_java_opts: >-
   -Djava.awt.headless=true
   -Xms1024m
   -Xmx1024m
-  -XX:PermSize=128m
-  -XX:MaxPermSize=128m
   -XX:+UseConcMarkSweepGC
   -Dcom.sun.management.jmxremote=true
   -Dcom.sun.management.jmxremote.port=9010


### PR DESCRIPTION
This memory space has been removed in Java 8 so the related settings are not releavant anymore.
So remove it from the example.