### PR TITLE
feat(livingapp): add '--http-timeout' option to 'livingapp deploy' command

### DIFF
--- a/md/bcd_cli.md
+++ b/md/bcd_cli.md
@@ -248,6 +248,12 @@ You can also see this information by running `bcd --help` and `bcd [COMMAND] --h
 </dd></dl>
 
 <dl class="option">
+<dt id="cmdoption-bcd-bcd-options-livingapp-deploy-http-timeout">
+<code class="descname">--http-timeout</code><code class="descclassname"> &lt;http_timeout&gt;</code></dt>
+<dd><p>Timeout in seconds for HTTP interactions with Bonita stack  [default: 120]</p>
+</dd></dl>
+
+<dl class="option">
 <dt id="cmdoption-bcd-bcd-options-livingapp-deploy-x">
 <code class="descname">-X</code><code class="descclassname"></code><code class="descclassname">, </code><code class="descname">--debug</code><code class="descclassname"></code></dt>
 <dd><p>Enable debug mode</p>

--- a/md/release_notes.md
+++ b/md/release_notes.md
@@ -1,16 +1,5 @@
 # Release notes
 
-## Breaking changes
-
-The following changes introduce incompatibility with BCD 2.x:
-
-* By default, BCD no longer retrieves its dependencies from the filesystem but uses a secured public Docker registry. So the following variables must be added to your scenarios:
-  ```
-  bcd_registry_user: YOUR_USER_TO_BCD_DOCKER_REGISTRY
-  bcd_registry_password: YOUR_PASS_TO_BCD_DOCKER_REGISTRY
-  ```
-  As a BCD customer, contact your sales representative to get your access to the secured registry.
-
 ## Limitations and known issues
 
 * The same BCD stack cannot be managed with multiple BCD controller instances due to the use of Terraform "local" backend.
@@ -19,22 +8,8 @@ The following changes introduce incompatibility with BCD 2.x:
   [WARNING]: Could not match supplied host pattern, ignoring: load_balancer
   ```
 
-## What's new in 3.0.1 (2019-03-07)
-
-### Bugfixes
-
-* BCD-323 Licenses are not deactivated with stack undeploy with Bonita 7.8.0
-
-## What's new in 3.0.0 (2018-12-06)
+## What's new in 3.1.0 (yyyy-mm-dd)
 
 ### New features
 
-* Manage Docker dependencies through a secured public registry
-* [Manage Bonita licenses](manage_bonita_licenses.md) with BCD sub-commands (`bcd license [generate,revoke]`)
-* <span class="label label-danger">Supported from Bonita 7.8.0 onwards</span> [Manage Living Apps Configuration](livingapp_manage_configuration.md) with BCD sub-commands (`bcd livingapp [extract-conf,merge-conf]`)
-* Create and delete Microsoft Azure resources for the Bonita stack automatically (`bcd_provider: azure`)
-
-### Enhancements
-
-* Enabling endpoint heuristics to guess endpoints for AWS regions that aren’t integrated yet into [boto](http://docs.pythonboto.org). For example, BCD can now manage the AWS region eu-west-3 (Paris) despite the issue [#3783](https://github.com/boto/boto/issues/3783) is still opened.
-* The `bonita_edition` variable is no longer used and it will be ignored if it is still defined in scenarios. The Bonita edition is automatically inferred from your subscription.
+* Configurable HTTP timeout for Living Apps deployment (default to 120 seconds)


### PR DESCRIPTION
- covers BCD-341