### PR TITLE
feat(docker-compose): bash history support (BCD-396)

### DIFF
--- a/md/bcd_controller.md
+++ b/md/bcd_controller.md
@@ -89,7 +89,7 @@ $ docker-compose run --rm bcd
 
 #### TIP: Persistent command history
 
-If you want to persist your bash command history across container restart, simply add the following environment line in your `docker-compose.yaml` file:
+If you want to persist your bash command history across container restarts, simply add the following environment line in your `docker-compose.yaml` file:
 
 ```yaml
 bcd:

--- a/md/bcd_controller.md
+++ b/md/bcd_controller.md
@@ -94,9 +94,9 @@ If you want to persist your bash command history across container restart, simpl
 ```yaml
 bcd:
  # lines omitted ...
+ ## Add or uncomment the following lines to persist your command history across bcd controller restart
  environment:
-     ## Add or uncomment the following line to persist your command history across bcd controller restart
-     - HISTFILE=/home/bonita/bonita-continuous-delivery/.bcd_bash_history
+  - HISTFILE=/home/bonita/bonita-continuous-delivery/.bcd_bash_history
 ```
 
 The history of your commands will be persisted to this file wich is located in your project home directory.

--- a/md/bcd_controller.md
+++ b/md/bcd_controller.md
@@ -24,10 +24,10 @@ To enter the BCD controller environment, a Docker container has to be started on
 Besides the following files have to be bind mounted from the control host to make them available to the BCD controller container:
 - **`/host/path/to/bonita-continuous-delivery_<version>`** (mounted as `/home/bonita/bonita-continuous-delivery`) - This directory provides BCD Ansible playbooks and is known as the `BCD_HOME` directory.
 - <div class="list-group-item list-group-item-warning">This file is required for <strong>Provisioning</strong>. It is not required for Living App management.</div>
-  
+
   **`ssh_private_key`** (mounted as `/home/bonita/.ssh/ssh_private_key`) - The `ssh_private_key` file is the SSH private key used to connect to your target machines. For AWS, this is the private part of your [EC2 key pair](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html). This file should only be accessible from your user (`chmod 600 ~/.ssh/ssh_private_key`).
 - <div class="list-group-item list-group-item-warning">AWS credentials are required for <strong>Provisioning on AWS</strong>. It is not required for Living App management.</div>
-  
+
   **`.boto`** (mounted as `/home/bonita/.boto`) - The [`.boto`](https://boto.readthedocs.io/en/latest/boto_config_tut.html) file contains AWS credentials used to make programmatic calls to AWS. Indeed dynamic Amazon EC2 inventory management for Ansible runs on top of [Boto](https://aws.amazon.com/sdk-for-python/). The content of a `.boto` file is as follows:
     ```ini
     [Credentials]
@@ -86,6 +86,20 @@ Then start the BCD controller container interactively with:
 ```
 $ docker-compose run --rm bcd
 ```
+
+#### TIP: Persistent command history
+
+If you want to persist your bash command history across container restart, simply add the following environment line in your `docker-compose.yaml` file:
+
+```yaml
+bcd:
+ # lines omitted ...
+ environment:
+     ## Add or uncomment the following line to persist your command history across bcd controller restart
+     - HISTFILE=/home/bonita/bonita-continuous-delivery/.bcd_bash_history
+```
+
+The history of your commands will be persisted to this file wich is located in your project home directory.
 
 
 ## Note for Linux users

--- a/md/upgrade_bcd.md
+++ b/md/upgrade_bcd.md
@@ -39,7 +39,7 @@ cp bonita-continuous-delivery_1.0.5/terraform/your_stack_name.tfstate bonita-con
 
 #### BCD controller
 
-As is described into the "Installation guide" from the [Getting started](getting_started.md) you will need to load the last version of `bcd-controller_<version>.tar.zip Docker image.
+As is described into the "Installation guide" from the [Getting started](getting_started.md) you will need to load the last version of `bcd-controller_<version>.tar.zip` Docker image.
 
 #### Vagrant
 
@@ -66,7 +66,14 @@ cp -r bonita-continuous-delivery_2.0.0/terraform/your_stack_name bonita-continuo
 
 #### BCD controller
 
-As is described into the "Installation guide" from the [Getting started](getting_started.md) you will need to load the last version of `bcd-controller_<version>.tar.zip Docker image.
+As is described into the "Installation guide" from the [Getting started](getting_started.md) you will need to load the last version of `bcd-controller_<version>.tar.zip` Docker image.
+
+If you choosed to persist your docker console history ([see bcd controller](bcd_controller.md)) and want to keep it, then you should copy your `.bcd_bash_history` file from your old folder to your
+new `bonita-continuous-delivery_${varVersion}.0/ folder`
+
+```bash
+$ cp bonita-continuous-delivery_2.1.0/.bcd_bash_history bonita-continuous-delivery_${varVersion}.0/.bcd_bash_history
+```
 
 #### Vagrant
 

--- a/md/upgrade_bcd.md
+++ b/md/upgrade_bcd.md
@@ -72,7 +72,7 @@ If you choosed to persist your docker console history ([see bcd controller](bcd_
 new `bonita-continuous-delivery_${varVersion}.0/ folder`
 
 ```bash
-$ cp bonita-continuous-delivery_2.1.0/.bcd_bash_history bonita-continuous-delivery_${varVersion}.0/.bcd_bash_history
+$ cp bonita-continuous-delivery_2.0.0/.bcd_bash_history bonita-continuous-delivery_2.0.2/.bcd_bash_history
 ```
 
 #### Vagrant


### PR DESCRIPTION
Add documentation for bash history support in BCD docker container.
(follow up of the previous PR https://github.com/bonitasoft/bonita-continuous-delivery-doc/pull/140 )