### PR TITLE
chore: change the way we trigger the documentation-site workflow

### DIFF
--- a/.github/workflows/push-content.yml
+++ b/.github/workflows/push-content.yml
@@ -6,18 +6,17 @@ on:
     branches:
       - 3.4_asciidoctor
     paths:
-      - 'modules/ROOT/**'
+      - 'modules/**'
       - 'antora.yml'
       - '.github/workflows/push-content.yml'
 jobs:
   triggerJob:
     runs-on: ubuntu-20.04
     steps:
-      - name: Workflow Dispatch
-        uses: benc-uk/workflow-dispatch@v1.1
+      - name: Notify content changes
+        uses: peter-evans/repository-dispatch@v1
         with:
-          workflow: Generate documentation
           token: ${{secrets.GH_TOKEN_DOC_TRIGGER_WF}}
-          ref: master
-          repo: bonitasoft/bonitasoft.github.io
-          inputs: '{ "component": "bcd", "branch": "3.4_asciidoctor" }'
+          repository: bonitasoft/bonita-documentation-site
+          event-type: source_documentation_change
+          client-payload: '{ "component": "bcd", "branch": "3.4_asciidoctor" }'

--- a/.github/workflows/push-content.yml
+++ b/.github/workflows/push-content.yml
@@ -19,4 +19,4 @@ jobs:
           token: ${{secrets.GH_TOKEN_DOC_TRIGGER_WF}}
           repository: bonitasoft/bonita-documentation-site
           event-type: source_documentation_change
-          client-payload: '{ "component": "bcd", "branch": "3.4_asciidoctor" }'
+          client-payload: '{ "component": "bcd", "branch": "3.4" }'


### PR DESCRIPTION
We are now using a repository_dispatch event to reduce adherence with the
targeted repository.

In addition
  - use the new `bonita-documentation-site` repository name
  - trigger on content change on all modules changes not only ROOT

covers https://github.com/bonitasoft/bonita-documentation-site/issues/167
