### PR TITLE
fix: asciidoc attribute substitution and broken links

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -3,6 +3,9 @@ title: Bonita Continuous Delivery
 version: 3.4
 asciidoc:
   attributes:
+    bcdVersion: '3.4.2' # latest available maintenance version
+    bonitaDocVersion: '2021.1'
+    # General site configuration
     page-editable: true
 nav:
   - modules/ROOT/taxonomy.adoc

--- a/modules/ROOT/pages/bcd_cli.adoc
+++ b/modules/ROOT/pages/bcd_cli.adoc
@@ -13,7 +13,7 @@ The BCD scenario path can also be specified through the *`BCD_SCENARIO`* environ
  ** `bonita-la-builder-*-exec.jar` - (Mandatory) The Bonita Living Application Builder library
  ** `bonita-sp-*-maven-repository.zip` - (Optional) The Bonita Maven repository zip if required by your Living Application workspace.
 Since BCD 3.0.0, dependencies can be retrieved as `quay.io/bonitasoft/bcd-dependencies:<bonita_version>` Docker images and they must be mounted as volumes in the `$BCD_HOME/dependencies` directory.
-You can read more about in link:getting_started.adoc#_common_installation_steps[Common installation steps]
+You can read more about in link:getting_started.adoc#common_installation_steps[Common installation steps]
 
 == Usage examples
 

--- a/modules/ROOT/pages/bcd_controller.adoc
+++ b/modules/ROOT/pages/bcd_controller.adoc
@@ -48,7 +48,7 @@ NOTE: However AWS credentials can be provided in other ways, for instance with x
 
 Once the required files are prepared, the BCD controller container can be started in different ways described hereafter.
 
-WARNING: For linux user make sure your `user id` and `group id` is `1000` or refer to the <<toc5,Running BCD controller with user ID different from 1000>> paragraph.
+WARNING: For linux user make sure your `user id` and `group id` is `1000` or refer to the <<user_id_not_1000,Running BCD controller with user ID different from 1000>> paragraph.
 
 
 === Starting a BCD controller with `docker run`
@@ -114,6 +114,7 @@ uid=1000(john) gid=1000(john) [...]
 
 If this is not so, then read the next section to know how to fix file ownership between the control host and the controller container.
 
+[#user_id_not_1000]
 === Running BCD controller with user ID different from 1000
 
 Here is one way to remap UID/GID of the controller's `bonita` user with your host user. It consists of extending the `bonitasoft/bcd-controller` Docker image by using the following `Dockerfile`:

--- a/modules/ROOT/pages/custom_init.adoc
+++ b/modules/ROOT/pages/custom_init.adoc
@@ -42,7 +42,7 @@ roles
 
 == When are custom initialization scripts invoked?
 
-Custom initialization scripts are invoked once the database has been initialized and the Tomcat server has been configured with https://documentation.bonitasoft.com/bonita/${bonitaDocVersion}/BonitaBPM_platform_setup[Bonita Platform setup tool].
+Custom initialization scripts are invoked once the database has been initialized and the Tomcat server has been configured with xref:{bonitaDocVersion}@bonita::BonitaBPM_platform_setup.adoc[Bonita Platform setup tool].
 
 Hence the Bonita Docker image startup sequence can be described as follows:
 
@@ -86,7 +86,7 @@ More precisely scripts are executed in the order returned by this command: `ls -
 === 1. config-workers.sh
 
 The `config-workers.sh` script is provided as part of BCD's core scripts. +
-In particular it shows how to further configure the server using https://documentation.bonitasoft.com/bonita/${bonitaDocVersion}/BonitaBPM_platform_setup[Bonita Platform setup tool].
+In particular it shows how to further configure the server using xref:{bonitaDocVersion}@bonita::BonitaBPM_platform_setup.adoc[Bonita Platform setup tool].
 
 === 2. config-cluster.sh.j2
 
@@ -95,7 +95,7 @@ In particular it shows how to conditionally configure a cluster deployment on AW
 
 === 3. register-event-handler.sh
 
-This sample script deploys and registers a Bonita engine Event handler as described in https://documentation.bonitasoft.com/bonita/${bonitaDocVersion}/event-handlers[Event handlers Documentation].
+This sample script deploys and registers a Bonita engine Event handler as described in xref:{bonitaDocVersion}@bonita::event-handlers.adoc[Event handlers Documentation].
 
 Assuming the following files:
 

--- a/modules/ROOT/pages/deploy-with-existing-database.adoc
+++ b/modules/ROOT/pages/deploy-with-existing-database.adoc
@@ -17,7 +17,7 @@ Example with Amazon RDS
 
 One typical use case is to deploy your Bonita stack using an https://aws.amazon.com/rds/[Amazon RDS] instance.
 
-. Prior to creating your RDS instance, create and customize a https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html[DB Parameter Group] in order to set database parameters for Bonita. Refer to Bonita documentation to check how to https://documentation.bonitasoft.com/bonita/${bonitaDocVersion}/database-configuration[Customize RDBMS to make it work with Bonita].
+. Prior to creating your RDS instance, create and customize a https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithParamGroups.html[DB Parameter Group] in order to set database parameters for Bonita. Refer to Bonita documentation to check how to xref:{bonitaDocVersion}@bonita::database-configuration.adoc[Customize RDBMS to make it work with Bonita].
 . Create your RDS instance using the DB parameter group created previously. Make sure the assigned security group allows access to the DB instance. +
 Leave the *Database Name* field empty to not create a database. BCD will create required databases automatically.
 . Report connection information into your BCD scenario:

--- a/modules/ROOT/pages/getting_started.adoc
+++ b/modules/ROOT/pages/getting_started.adoc
@@ -12,6 +12,7 @@ Then a *BCD Controller container* has to be started on the control host, ie. the
 
 image::images/bcd_controller.png[Bonita Continuous Delivery Controller]
 
+[#common_installation_steps]
 === Common installation steps
 
 Follow these installation steps on your control host.

--- a/modules/ROOT/pages/how_to_configure_rest_api_authorization.adoc
+++ b/modules/ROOT/pages/how_to_configure_rest_api_authorization.adoc
@@ -1,9 +1,9 @@
 = How to configure REST API authorization
 
 The Bonita container is launched with REST_API_DYN_AUTH_CHECKS flag set to true by default. +
-It means that all https://documentation.bonitasoft.com/bonita/${bonitaDocVersion}/rest-api-authorization#toc2[dynamic permissions checks] are activated.
+It means that all xref:{bonitaDocVersion}@bonita::rest-api-authorization.adoc#dynamic_authorization[dynamic permissions checks] are activated.
 
-In the sections below we will manipluate configuration into templates and not at a specific tenant. Indeed the default tenant (1) will be created during the first startup of bonita.
+In the sections below, we will manipulate configuration into templates and not at a specific tenant. Indeed, the default tenant (1) will be created during the first startup of bonita.
 
 == Deactivating dynamic permissions checks
 
@@ -17,7 +17,7 @@ bonita_rest_api_dyn_auth_checks: false
 
 == Adding custom permissions
 
-As described in https://documentation.bonitasoft.com/bonita/${bonitaDocVersion}/rest-api-authorization?hash=debug#toc1[Bonita documentation], the custom-permissions-mapping.properties file contains custom rules that supplement the resource permissions and compound permissions. By default, this file is empty, because the compound permissions definitions automatically manage the permissions needed for default and custom profiles, and for default and custom pages.
+As described in xref:{bonitaDocVersion}@bonita::rest-api-authorization.adoc#static_authorization[Bonita documentation], the custom-permissions-mapping.properties file contains custom rules that supplement the resource permissions and compound permissions. By default, this file is empty, because the compound permissions definitions automatically manage the permissions needed for default and custom profiles, and for default and custom pages.
 
 If you want to override the default behavior, you can add rules to this file by adding this kind of script `roles/bonita/files/custom-init.d/add-custom-permissions.sh`
 
@@ -74,7 +74,7 @@ touch ${indicator_path}
 
 == Enabling debug mode
 
-If https://documentation.bonitasoft.com/bonita/${bonitaDocVersion}/rest-api-authorization?hash=debug[debug mode] is activated, whenever you update a configuration file or a dynamic check script, the changes take effect immediately.
+If xref:{bonitaDocVersion}@bonita::rest-api-authorization.adoc#debug[debug mode] is activated, whenever you update a configuration file, or a dynamic check script, the changes take effect immediately.
 
 To activate debug mode you can create a script like `roles/bonita/files/custom-init.d/activate-debug-mode.sh`
 

--- a/modules/ROOT/pages/livingapp_build.adoc
+++ b/modules/ROOT/pages/livingapp_build.adoc
@@ -2,7 +2,7 @@
 
 This tutorial describes how to build a Bonita Living Application repository from the command line using BCD.
 
-NOTE: A Living Application repository (or *Living App repository*) contains the artifacts developed in Bonita Studio and the UI Designer. Its content is further described in https://documentation.bonitasoft.com/bonita/${bonitaDocVersion}/workspaces-and-repositories[Bonita's Workspaces and repositories documentation] page.
+NOTE: A Living Application repository (or *Living App repository*) contains the artifacts developed in Bonita Studio and the UI Designer. Its content is further described in xref:{bonitaDocVersion}@bonita::workspaces-and-repositories.adoc[Bonita's Workspaces and repositories documentation] page.
 
 
 The repository build process allows to generate Bonita deployable artifacts (for instance process `.bar` files, UI Designer pages `.zip` files, REST API extensions `.zip` files).
@@ -11,7 +11,7 @@ The repository build process allows to generate Bonita deployable artifacts (for
 
 === 1. Prepare the repository
 
-A Living App repository can be created using Bonita Studio and it can be https://documentation.bonitasoft.com/bonita/${bonitaDocVersion}/workspaces-and-repositories#toc5[shared with Git or SVN].
+A Living App repository can be created using Bonita Studio and it can be xref:{bonitaDocVersion}@bonita::workspaces-and-repositories.adoc#_use_a_shared_project[shared with Git or SVN].
 
 So first ensure you have your Living App repository available on your filesystem. +
 For this tutorial, we will use the https://github.com/bonitasoft/bonita-vacation-management-example[Bonita Vacation Management example repository] publicly available on GitHub.
@@ -38,7 +38,7 @@ For instance the `bonita-la-builder-7.11.0-exec.jar` file must be present to bui
 
 ==== bonita-sp-<bonita_version>-maven-repository.zip
 
-Bonita Maven repository zip files if your repository contains https://documentation.bonitasoft.com/bonita/${bonitaDocVersion}/api-extensions[REST API extensions]. The version of the Maven repository zip must correspond to the `bonita.version` property defined in your REST API extension's `pom.xml`.
+Bonita Maven repository zip files if your repository contains xref:{bonitaDocVersion}@bonita::api-extensions.adoc[REST API extensions]. The version of the Maven repository zip must correspond to the `bonita.version` property defined in your REST API extension's `pom.xml`.
 
 NOTE: Starting from BCD 3.4.0, you can directly mount your docker host `~/.m2` folder to the `/home/bonita/.m2` folder in BCD controller container using docker volume !
 You will benefit from your already defined maven configuration from `~/.m2/settings.xml` (like mirrors or proxy configuration), and the already cached maven artifacts in your `~/.m2/repository` folder
@@ -78,7 +78,7 @@ If versions do not match, the `bcd livingapp build` command will exit with such 
 [13:46:34.469] ERROR: Aborting! Command <livingapp-build> returned non-zero exit code <1>
 ----
 
-The `bcd livingapp build` command does not allow to migrate your repository to the builder's version. Your repository has to be migrated to the appropriate version using https://documentation.bonitasoft.com/bonita/${bonitaDocVersion}/workspaces-and-repositories#toc6[Bonita Studio].
+The `bcd livingapp build` command does not allow to migrate your repository to the builder's version. Your repository has to be migrated to the appropriate version using xref:{bonitaDocVersion}@bonita::workspaces-and-repositories.adoc[Bonita Studio].
 
 == Complete example
 

--- a/modules/ROOT/pages/livingapp_build_and_deploy.adoc
+++ b/modules/ROOT/pages/livingapp_build_and_deploy.adoc
@@ -32,7 +32,7 @@ Before to perform an important change on a resource, make sure to save the curre
 *We do not recommend* to _duplicate_ the resource in your repository. If you start to manage your versions this way, your repository will get bigger and bigger, and the time required by the _Bonita Living Application Builder_ to build your repository will increase. Moreover, it is really painful to work on a repository containing all the history of a project, it can lead to many confusions and errors during the development ( dependency issues ...).
 
 *The recommended way* is definitively to keep the latest version of each resources in the working repository, and the history on your Version Control System. +
-Since the version 7.7.0 of Bonita, the popular Version Control System _Git_ is integrated in Bonita Studio. It is a fine way to manage properly the versioning of your projects. The Bonita documentation provides an example on https://documentation.bonitasoft.com/bonita/${bonitaDocVersion}/share-a-repository-on-github[how to share a repository on GitHub].
+Since the version 7.7.0 of Bonita, the popular Version Control System _Git_ is integrated in Bonita Studio. It is a fine way to manage properly the versioning of your projects. The Bonita documentation provides an example on xref:{bonitaDocVersion}@bonita::share-a-repository-on-github.adoc[how to share a repository on GitHub].
 
 == Build and deploy straight
 

--- a/modules/ROOT/pages/livingapp_deploy.adoc
+++ b/modules/ROOT/pages/livingapp_deploy.adoc
@@ -142,6 +142,7 @@ Each artifact to deploy must be defined with the following attributes:
 }
 ----
 
+[#supported-policies]
 === Supported Policies
 
 * Applications:
@@ -166,7 +167,7 @@ Each artifact to deploy must be defined with the following attributes:
 === Caveats
 
 * `FAIL` policy implies that the deployment stops right after the failure meaning that subsequent elements of the deployment are not deployed at all.
-* Prior to deploying a Business Data Model, https://documentation.bonitasoft.com/bonita/${bonitaDocVersion}/pause-and-resume-bpm-services[the Bonita tenant is paused]. So a downtime of the tenant occurs. The tenant is resumed after the deployment of the BDM.
+* Prior to deploying a Business Data Model, xref:{bonitaDocVersion}@bonita::pause-and-resume-bpm-services.adoc[the Bonita tenant is paused]. So a downtime of the tenant occurs. The tenant is resumed after the deployment of the BDM.
 * REST API extension authorizations are not configured as part of the deployment process. They have to be configured while provisioning the Bonita platform. See xref:how_to_configure_rest_api_authorization.adoc[how to configure REST API authorization] with BCD.
 
 == How to use

--- a/modules/ROOT/pages/livingapp_manage_configuration.adoc
+++ b/modules/ROOT/pages/livingapp_manage_configuration.adoc
@@ -9,7 +9,7 @@ This tutorial describes how to configure your Bonita Living Application from the
 Since BCD 3.0.0 and with Bonita 7.8.0 onwards, if you build a Living Application you will get separately:
 
 * a zip file which contains binaries
-* a bconf file which contains the configuration for the target https://documentation.bonitasoft.com/bonita/${bonitaDocVersion}/environments[environment] (Local by default)
+* a bconf file which contains the configuration for the target xref:{bonitaDocVersion}@bonita::environments.adoc[environment] (Local by default)
 
 Here is an example of a build result:
 

--- a/modules/ROOT/pages/manage_bonita_licenses.adoc
+++ b/modules/ROOT/pages/manage_bonita_licenses.adoc
@@ -8,7 +8,7 @@ This feature lets you generate licenses programmatically for your Bonita Studio 
 To use this feature, you need to prepare a link:scenarios[scenario file] with the following required information:
 
 * The `bonita_version` variable
-* xref:scenarios.adoc#_licensing_variables[licensing variables in scenarios]
+* xref:scenarios.adoc#licensing_variables[licensing variables in scenarios]
 
 NOTE: An example scenario is provided with the *scenarios/manage_licenses.yml.EXAMPLE* file with required variables to manage
 Bonita licenses with BCD.
@@ -16,7 +16,7 @@ Bonita licenses with BCD.
 
 == Generating a new license
 
-You can generate a new license providing a *Request Key*. Read more about Bonita licenses and how to generate a request key on this https://documentation.bonitasoft.com/bonita/${bonitaDocVersion}/licenses#toc2[documentation page].
+You can generate a new license providing a *Request Key*. Read more about Bonita licenses and how to generate a request key on this xref:{bonitaDocVersion}@bonita::licenses.adoc#_get_a_new_license[documentation page].
 
 NOTE: The request key has to be generated on the host where your Bonita Studio or Bonita Server will be running.
 

--- a/modules/ROOT/pages/release_notes.adoc
+++ b/modules/ROOT/pages/release_notes.adoc
@@ -2,7 +2,7 @@
 
 == What's new in 3.4.2
 
-Bonita versioning changed but BCD still refers to semantic versions, see https://documentation.bonitasoft.com/bonita/${bonitaDocVersion}/product-versioning#toc1[versions matrix] to see what technical version you need to use for a given bonita version (i.e. 20212.1 \=> 7.12.1)
+Bonita versioning changed but BCD still refers to semantic versions, see xref:{bonitaDocVersion}@bonita::product-versioning.adoc#_technical_id[versions matrix] to see what technical version you need to use for a given bonita version (i.e. 20212.1 \=> 7.12.1)
 
 === Breaking changes
 

--- a/modules/ROOT/pages/requirements-and-compatibility.adoc
+++ b/modules/ROOT/pages/requirements-and-compatibility.adoc
@@ -78,6 +78,5 @@ WARNING: If a Bonita release is not listed in the previous table, then it is not
 == Databases supported
 
 The databases supported with BCD are: PostgreSQL, MySQL and Oracle. +
-As BCD manages Bonita in the Tomcat Bundle and there is a https://documentation.bonitasoft.com/bonita/${bonitaDocVersion}/database-configuration#toc5[known issue between Bitronix and the Microsoft SQL Server], SQL Server is not supported. +
 By default, BCD provisions a database Docker container while deploying your Bonita stack. +
 But alternatively, BCD also lets you xref:deploy-with-existing-database.adoc[connect your Bonita stack with an existing database server (on-premise or in the cloud)].

--- a/modules/ROOT/pages/scenarios.adoc
+++ b/modules/ROOT/pages/scenarios.adoc
@@ -298,13 +298,13 @@ The following parameters are specific to the Bonita instances.
 | bonita_http_api
 | N
 | false
-| Activates the Bonita https://documentation.bonitasoft.com/bonita/${bonitaDocVersion}/rest-api-authorization#toc9[HTTP API].
+| Activates the Bonita xref:{bonitaDocVersion}@bonita::rest-api-authorization.adoc#_activating_and_deactivating_authorization[HTTP API].
 | true
 
 | bonita_rest_api_dyn_auth_checks
 | N
 | true
-| Activates https://documentation.bonitasoft.com/bonita/${bonitaDocVersion}/rest-api-authorization#toc2[dynamic authorization checking] on REST API.
+| Activates xref:{bonitaDocVersion}@bonita::rest-api-authorization.adoc##dynamic_authorization[dynamic authorization checking] on REST API.
 | false
 
 | bonita_published_ports_extra
@@ -314,6 +314,7 @@ The following parameters are specific to the Bonita instances.
 | [ '9020:9010', '2222:1111' ]
 |===
 
+[#licensing_variables]
 == Licensing variables
 
 In order that BCD retrieves Bonita licenses during the deployment of your platform, you need to set the following variables in your scenario:

--- a/modules/ROOT/pages/upgrade_bcd.adoc
+++ b/modules/ROOT/pages/upgrade_bcd.adoc
@@ -12,40 +12,38 @@ We will focus on :
 
 * scenarios : indeed you may want to keep your existing scenarios. It will allow you to recreate the same kind of stack or manipulate an existing one (deploy, undeploy, destroy).
 * Terraform metadata : "Terraform must store state about your managed infrastructure and configuration. This state is used by Terraform to map real world resources to your configuration, keep track of metadata, and to improve performance for large infrastructures." https://www.terraform.io/docs/state/.
-So if you want to be able to manage an existing stack (i.e. a stack already deployed from a previous version of BCD) you will need to copy paste this state.
++
+So if you want to be able to manage an existing stack (i.e. a stack already deployed from a previous version of BCD), you will need to copy and paste this state.
 * bcd controller
 * Vagrant : this part applies only if you use Vagrant virtual machines.
 * Living Application repositories : this part applies only for migrations from a 2.0.x
 
 == How it works
 
-=== From a 1.0.x towards a $\{varVersion}.y
-
-Please follow the previous documentation describing the https://documentation.bonitasoft.com/bcd/2.1/upgrade_bcd[upgrade from 1.0 toward 2.1]. Then follow the instructions in the next section.
-
-=== From a 2.1.x towards a $\{varVersion}.y
+=== From a 2.1.x towards {bcdVersion}
 
 ==== Scenarios
 
 First, you will need to copy the files:
 
-[source,bash]
+// for the 'subs' parameter, see https://docs.asciidoctor.org/asciidoc/latest/subs/apply-subs-to-blocks/
+[source,bash,subs="+macros"]
 ----
-$ cp bonita-continuous-delivery_2.1.0/scenarios/*.yml bonita-continuous-delivery_${varVersion}.0/scenarios/
+$ cp bonita-continuous-delivery_2.1.0/scenarios/*.yml bonita-continuous-delivery_pass:a[{bcdVersion}]/scenarios/
 ----
 
 Then you will have to check `Breaking changes` section in the xref:release_notes.adoc[release notes]. Indeed you will have to add the new variables `bcd_registry_user` and  `bcd_registry_password` in order to retrieve BCD dependencies from Bonita secured Docker registry.
 
 Besides, the `bonita_edition` variable has been deprecated in BCD 3.0.0 (read xref:release_notes.adoc[BCD 3.0.0 Release Notes] for further details). +
-Therefore you may remove this variable from your scenario files as it will be ignored.
+Therefore, you may remove this variable from your scenario files as it will be ignored.
 
 ==== Terraform
 
 Copy the directory corresponding to your stack:
 
-[source,bash]
+[source,bash,subs="+macros"]
 ----
-$ cp -r bonita-continuous-delivery_2.1.0/terraform/your_stack_name bonita-continuous-delivery_${varVersion}.0/terraform/
+$ cp -r bonita-continuous-delivery_2.1.0/terraform/your_stack_name bonita-continuous-delivery_pass:a[{bcdVersion}]/terraform/
 ----
 
 ==== BCD controller
@@ -53,7 +51,7 @@ $ cp -r bonita-continuous-delivery_2.1.0/terraform/your_stack_name bonita-contin
 As is described in the "Installation guide" from the xref:getting_started.adoc[Getting started] you will need to load the last version of `bcd-controller_<version>.tar.zip` Docker image. +
 You can also directly use the secured Docker registry to retrieve the latest image.
 
-[source,bash]
+[source,bash,subs="+macros"]
 ----
 $ docker login quay.io
 Username: bonitasoft+john_doe_at_acme_com
@@ -63,29 +61,28 @@ $ docker pull quay.io/bonitasoft/bcd-controller
 
 The username corresponds to `bcd_registry_user` and the password corresponds to `bcd_registry_password` described in the xref:scenarios.adoc[Scenario file reference]. Both have been provided by your sales representative.
 
-If you choosed to persist your docker console history (xref:bcd_controller.adoc[see bcd controller]) and want to keep it, then you should copy your `.bcd_bash_history` file from your old folder to your new `+bonita-continuous-delivery_${varVersion}.0/+` folder
+If you chose to persist your docker console history (xref:bcd_controller.adoc[see bcd controller]) and want to keep it, then you should copy your `.bcd_bash_history` file from your old folder to your new `bonita-continuous-delivery_{bcdVersion}/` folder
 
-[source,bash]
+[source,bash,subs="+macros"]
 ----
-$ cp bonita-continuous-delivery_2.1.0/.bcd_bash_history bonita-continuous-delivery_${varVersion}.0/.bcd_bash_history
+$ cp bonita-continuous-delivery_2.1.0/.bcd_bash_history bonita-continuous-delivery_pass:a[{bcdVersion}]/.bcd_bash_history
 ----
 
- warn
-*BCD Controller image starting from version 3.4 is now using a `Debian` based distribution (not an Alpine Linux anymore)*
+WARNING: *BCD Controller image starting from version 3.4 is now using a `Debian` based distribution (not an Alpine Linux anymore)*
 
-If you have a customized controller in your setup (ie. to manage user id mapping), you'll have to rebuild it and perform changes required from Alpine to Debian.
+If you have a customized controller in your setup (i.e. to manage user id mapping), you'll have to rebuild it and perform changes required from Alpine to Debian.
 
 
 ==== Vagrant
 
 As the controller access to them over the network it's not necessary to move them on the filesystem.
 
-But if you plan to cleanup the old directory you can moved the vagrant data located inside `1-machine` or `2-machines` directories by copying the `.vagrant` subdirectories.
+But if you plan to clean up the old directory you can move the vagrant data located inside `1-machine` or `2-machines` directories by copying the `.vagrant` subdirectories.
 
-[source,bash]
+[source,bash,subs="+macros"]
 ----
-$ cp -r bonita-continuous-delivery_2.1.0/vagrant/1-machine/.vagrant bonita-continuous-delivery_${varVersion}.0/vagrant/1-machine/
-$ cp -r bonita-continuous-delivery_2.1.0/vagrant/2-machines/.vagrant bonita-continuous-delivery_${varVersion}.0/vagrant/2-machines/
+$ cp -r bonita-continuous-delivery_2.1.0/vagrant/1-machine/.vagrant bonita-continuous-delivery_pass:a[{bcdVersion}]/vagrant/1-machine/
+$ cp -r bonita-continuous-delivery_2.1.0/vagrant/2-machines/.vagrant bonita-continuous-delivery_pass:a[{bcdVersion}]/vagrant/2-machines/
 ----
 
 ==== Living Application repositories
@@ -94,7 +91,7 @@ Move the directories where you have cloned your repositories.
 
 For example :
 
-[source,bash]
+[source,bash,subs="+macros"]
 ----
-$ cp -r bonita-continuous-delivery_2.1.0/bonita-vacation-management-example bonita-continuous-delivery_${varVersion}.0/bonita-vacation-management-example
+$ cp -r bonita-continuous-delivery_2.1.0/bonita-vacation-management-example bonita-continuous-delivery_pass:a[{bcdVersion}]/bonita-vacation-management-example
 ----


### PR DESCRIPTION
Links to bonita documentation:
  - use antora cross component xref instead of hard coding the production url,
  see https://docs.antora.org/antora/2.3/page/version-and-component-xrefs/
  - fix bonita doc xref using anchors

Introduce asciidoc attributes
  - rename the `varVersion` attribute for clarity
  - fix not substituted asciidoc attributes in examples

Content removal due to targeted links that don't exist anymore
  - upgrade bcd: remove the '1.0.x towards ...' paragraph
  The bcd 2.1 documentation doesn't exist anymore, so we can not put a link to
  the related documentation page
  - release notes: no more sql server restriction with the Bonita Bundle