### PR TITLE
update(troubleshooting-guide): Compilation error message

### DIFF
--- a/modules/ROOT/pages/troubleshooting_guide.adoc
+++ b/modules/ROOT/pages/troubleshooting_guide.adoc
@@ -156,7 +156,7 @@ java.io.IOException: Maven build failed.
 ----
 
 The REST API Extension involved was created with a lower version of the Bontia product.  
-There are java librarires (`.jar` files) which are not compatible with java 11 used with laatest version of BCD (specifically with latest `bonita-la-builder-*-exec.jar` AKA LA Builder).  
+There are java librarires (`.jar` files) which are not compatible with java 11 used with latest version of BCD (specifically with latest `bonita-la-builder-*-exec.jar` AKA LA Builder).  
 
 The Maven's `pom.xml` file needs to be modified. The versions of the dependency and plugins listed below must be updated:
 
@@ -165,7 +165,7 @@ The Maven's `pom.xml` file needs to be modified. The versions of the dependency 
 * plugin `groovy-eclipse-compiler`
 * plugin `groovy-eclipse-batch`
 
-In order to find the versions to use, start your Studio current version, and create a new dummy REST API extension: report the versions found in the new `pom.xml` file created into the REST API extensions ` pom/xml` files which failed to be compiled.  
+In order to find the versions to use, start your Studio current version, and create a new dummy REST API extension: report the versions found in the new `pom.xml` file created into the REST API extensions ` pom.xml` files which failed to be compiled.  
 
 
 == Debugging Ansible Facts

--- a/modules/ROOT/pages/troubleshooting_guide.adoc
+++ b/modules/ROOT/pages/troubleshooting_guide.adoc
@@ -156,7 +156,7 @@ java.io.IOException: Maven build failed.
 ----
 
 The REST API Extension involved was created with a lower version of the Bontia product.  
-There are java librarires (`.jar` files) which are not compatible with java 11 used with latest version of BCD (specifically with latest `bonita-la-builder-*-exec.jar` AKA LA Builder).  
+There are java librarires (`.jar` files) which are not compatible with java 11 used with latest version of BCD.  
 
 The Maven's `pom.xml` file needs to be modified. The versions of the dependency and plugins listed below must be updated:
 

--- a/modules/ROOT/pages/troubleshooting_guide.adoc
+++ b/modules/ROOT/pages/troubleshooting_guide.adoc
@@ -99,7 +99,7 @@ scp -i ~/.ssh/my_key.pem ubuntu@54.191.90.85:/tmp/logs /tmp/
 ----
 
 
-== A REST API Extension compilation generate errors
+== A REST API Extension compilation generates errors
 
 The `bcd ... livingapp build ...` failed to generate the REST API Extensions with these error messages below: 
 [source,bash]
@@ -165,7 +165,11 @@ The Maven's `pom.xml` file needs to be modified. The versions of the dependency 
 * plugin `groovy-eclipse-compiler`
 * plugin `groovy-eclipse-batch`
 
-In order to find the versions to use, start your Studio current version, and create a new dummy REST API extension: report the versions found in the new `pom.xml` file created into the REST API extensions ` pom.xml` files which failed to be compiled.  
+In order to find the versions to use, apply the procédure below:
+
+* Start the Studio
+* Create a new dummy REST API extension: the new `pom.xml` file created contains the versions to used
+* Update the `pom.xml` file of the REST API Extension which failed to be compiled.  
 
 
 == Debugging Ansible Facts

--- a/modules/ROOT/pages/troubleshooting_guide.adoc
+++ b/modules/ROOT/pages/troubleshooting_guide.adoc
@@ -98,6 +98,76 @@ Then you will be able to retrieve all the files through a `scp`:
 scp -i ~/.ssh/my_key.pem ubuntu@54.191.90.85:/tmp/logs /tmp/
 ----
 
+
+== A REST API Extension compilation generate errors
+
+The `bcd ... livingapp build ...` failed to generate the REST API Extensions with these error messages below: 
+[source,bash]
+----
+...
+[INFO] 
+[INFO] --- maven-compiler-plugin:3.6.0:compile (default-compile) @ tankLevelRestAPI ---
+[INFO] Changes detected - recompiling the module!
+[INFO] Using Groovy-Eclipse compiler to compile both Java and Groovy files
+[INFO] -------------------------------------------------------------
+[ERROR] COMPILATION ERROR : 
+[INFO] -------------------------------------------------------------
+[ERROR] /workspace/CarProject/restAPIExtensions/tankLevelRestAPI/src/main/groovy/com/support/bonitasoft/rest/api/Index.groovy:[1,1] 1. ERROR in /workspace/CarProject/restAPIExtensions/tankLevelRestAPI/src/main/groovy/com/support/bonitasoft/rest/api/Index.groovy (at line 1)
+	package com.support.bonitasoft.rest.api;
+	^
+The type java.lang.Object cannot be resolved. It is indirectly referenced from required .class files
+
+[ERROR] /workspace/CarProject/restAPIExtensions/tankLevelRestAPI/src/main/groovy/com/support/bonitasoft/rest/api/Index.groovy:[1,1] 2. ERROR in /workspace/CarProject/restAPIExtensions/tankLevelRestAPI/src/main/groovy/com/support/bonitasoft/rest/api/Index.groovy (at line 1)
+	package com.support.bonitasoft.rest.api;
+	^
+The type java.lang.String cannot be resolved. It is indirectly referenced from required .class files
+...
+[ERROR] /workspace/CarProject/restAPIExtensions/tankLevelRestAPI/src/main/groovy/com/support/bonitasoft/rest/api/Index.groovy:[100,61] 21. ERROR in /workspace/CarProject/restAPIExtensions/tankLevelRestAPI/src/main/groovy/com/support/bonitasoft/rest/api/Index.groovy (at line 100)
+	resourceProvider.getResourceAsStream(fileName).withStream { InputStream s ->
+	                                                            ^^^^^^^^^^^
+Groovy:unable to resolve class InputStream 
+
+[ERROR] Found 21 errors and 0 warnings.
+[INFO] 22 errors 
+[INFO] -------------------------------------------------------------
+[INFO] ------------------------------------------------------------------------
+[INFO] BUILD FAILURE
+[INFO] ------------------------------------------------------------------------
+...
+[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.6.0:compile (default-compile) on project tankLevelRestAPI: Compilation failure: Compilation failure: 
+[ERROR] /workspace/CarProject/restAPIExtensions/tankLevelRestAPI/src/main/groovy/com/support/bonitasoft/rest/api/Index.groovy:[1,1] 1. ERROR in /workspace/CarProject/restAPIExtensions/tankLevelRestAPI/src/main/groovy/com/support/bonitasoft/rest/api/Index.groovy (at line 1)
+[ERROR] 	package com.support.bonitasoft.rest.api;
+[ERROR] 	^
+[ERROR] The type java.lang.Object cannot be resolved. It is indirectly referenced from required .class files
+...
+[ERROR] Found 21 errors and 0 warnings.
+...
+[ERROR] Failed to build /workspace/CarProject/restAPIExtensions/tankLevelRestAPI
+java.io.IOException: Maven build failed.
+	at com.bonitasoft.la.builder.task.AbstractCustomPageProjectTask.runMavenInstall(AbstractCustomPageProjectTask.java:64)
+	at com.bonitasoft.la.builder.task.AbstractCustomPageProjectTask.execute(AbstractCustomPageProjectTask.java:45)
+	at com.bonitasoft.la.builder.task.TaskExecutor.lambda$build$0(TaskExecutor.java:37)
+	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)
+	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:658)
+	at com.bonitasoft.la.builder.task.TaskExecutor.build(TaskExecutor.java:34)
+	at com.bonitasoft.la.builder.BuilderCLI.run(BuilderCLI.java:142)
+	at com.bonitasoft.la.builder.BuilderCLI.buildCmd(BuilderCLI.java:126)
+	at com.bonitasoft.la.builder.BuilderCLI.main(BuilderCLI.java:82)
+----
+
+The REST API Extension involved was created with a lower version of the Bontia product.  
+There are java librarires (`.jar` files) which are not compatible with java 11 used with laatest version of BCD (specifically with latest `bonita-la-builder-*-exec.jar` AKA LA Builder).  
+
+The Maven's `pom.xml` file needs to be modified. The versions of the dependency and plugins listed below must be updated:
+
+* dependency `groovy-all`
+* plugin `maven-compiler-plugin`
+* plugin `groovy-eclipse-compiler`
+* plugin `groovy-eclipse-batch`
+
+In order to find the versions to use, start your Studio current version, and create a new dummy REST API extension: report the versions found in the new `pom.xml` file created into the REST API extensions ` pom/xml` files which failed to be compiled.  
+
+
 == Debugging Ansible Facts
 
 Ansible facts are local variables registered in hosts. It is possible to save them in JSON files with the `setup` command.
@@ -149,3 +219,5 @@ drwxr-xr-x 2 root   root                 4096 janv. 6  2020 7.11.3 # <= this fol
 
 To properly map your own user to the user inside the BCD controller image,
 see the `Running BCD controller with user ID different from 1000` paragraph in xref:bcd_controller.adoc[BCD Controller image]
+
+


### PR DESCRIPTION
Compalation errors generated with REST API Extensions created with old version of the product (when build with JDK 8).

plz propagate to all BCD versions using jdk 11