### PR TITLE
fix(bcd-controller): add version in example

### DIFF
--- a/modules/ROOT/pages/bcd_controller.adoc
+++ b/modules/ROOT/pages/bcd_controller.adoc
@@ -64,7 +64,7 @@ $ docker run --rm -t -i --name bcd-controller \
     -v <host_path_to_.boto>:/home/bonita/.boto \
     -v <host_path_to_bonita-continuous-delivery_folder>:/home/bonita/bonita-continuous-delivery \
     -v <host_path_to_ssh_private_key>:/home/bonita/.ssh/<ssh_private_key> \
-    quay.io/bonitasoft/bcd-controller /bin/bash
+    quay.io/bonitasoft/bcd-controller:<version> /bin/bash
 ----
 
 === Starting a BCD controller with `docker-compose run`

--- a/modules/ROOT/pages/bcd_controller.adoc
+++ b/modules/ROOT/pages/bcd_controller.adoc
@@ -8,12 +8,12 @@ Since BCD 3.0.0, the BCD controller image is provided through Quay.io registry.
 
 Get this image as follows:
 
-[source,bash]
+[source,bash,subs="attributes"]
 ----
 $ docker login quay.io
 Username: bonitasoft+john_doe_at_acme_com
 Password:
-$ docker pull quay.io/bonitasoft/bcd-controller:<version>
+$ docker pull quay.io/bonitasoft/bcd-controller:{bcdVersion}
 ----
 
 The username corresponds to `bcd_registry_user` and the password corresponds to `bcd_registry_password` described in the xref:scenarios.adoc[Scenario file reference]. Both have been provided by your sales representative.
@@ -57,14 +57,14 @@ The first method to start a BCD Controller Docker container on the control host 
 
 *Example*:
 
-[source,bash]
+[source,bash,subs="attributes"]
 ----
 $ docker run --rm -t -i --name bcd-controller \
     -v bcd-dependencies-<bonita_version>:/home/bonita/bonita-continuous-delivery/dependencies/<bonita_version>  \
     -v <host_path_to_.boto>:/home/bonita/.boto \
     -v <host_path_to_bonita-continuous-delivery_folder>:/home/bonita/bonita-continuous-delivery \
     -v <host_path_to_ssh_private_key>:/home/bonita/.ssh/<ssh_private_key> \
-    quay.io/bonitasoft/bcd-controller:<version> /bin/bash
+    quay.io/bonitasoft/bcd-controller:{bcdVersion} /bin/bash
 ----
 
 === Starting a BCD controller with `docker-compose run`
@@ -119,9 +119,9 @@ If this is not so, then read the next section to know how to fix file ownership 
 
 Here is one way to remap UID/GID of the controller's `bonita` user with your host user. It consists of extending the `bonitasoft/bcd-controller` Docker image by using the following `Dockerfile`:
 
-[source,dockerfile]
+[source,dockerfile,subs="attributes"]
 ----
-FROM quay.io/bonitasoft/bcd-controller
+FROM quay.io/bonitasoft/bcd-controller:{bcdVersion}
 
 ARG BONITA_UID
 ARG BONITA_GID

--- a/modules/ROOT/pages/bcd_controller.adoc
+++ b/modules/ROOT/pages/bcd_controller.adoc
@@ -24,7 +24,7 @@ To enter the BCD controller environment, a Docker container has to be started on
 
 Besides the following files have to be bind mounted from the control host to make them available to the BCD controller container:
 
-* *`/host/path/to/bonita-continuous-delivery_<version>`* (mounted as `/home/bonita/bonita-continuous-delivery`) - This directory provides BCD Ansible playbooks and is known as the `BCD_HOME` directory.
+* *`/host/path/to/bonita-continuous-delivery_{bcdVersion}`* (mounted as `/home/bonita/bonita-continuous-delivery`) - This directory provides BCD Ansible playbooks and is known as the `BCD_HOME` directory.
 * {blank}
 +
 This file is required for *Provisioning*. It is not required for Living App management.

--- a/modules/ROOT/pages/deploy_with_static_inventory.adoc
+++ b/modules/ROOT/pages/deploy_with_static_inventory.adoc
@@ -85,12 +85,12 @@ $ VBoxManage list runningvms
 
 Copy the *vagrant_single.yml.EXAMPLE* to a *scenarios/vagrant_single.yml* file. Edit your scenario as necessary and start a BCD controller.
 
-[source,bash]
+[source,bash,subs="attributes"]
 ----
 $ docker run --rm -ti --hostname bcd-controller --name bcd-controller \
         -v ~/bonita-continuous-delivery_3.4.1:/home/bonita/bonita-continuous-delivery \
         -v ~/.vagrant.d/insecure_private_key:/home/bonita/.vagrant.d/insecure_private_key \
-        quay.io/bonitasoft/bcd-controller /bin/bash
+        quay.io/bonitasoft/bcd-controller:{bcdVersion} /bin/bash
 bonita@bcd-controller:~$ cd bonita-continuous-delivery
 bonita@bcd-controller:~/bonita-continuous-delivery$
 bonita@bcd-controller:~/bonita-continuous-delivery$bcd -s scenarios/vagrant_single.yml stack deploy

--- a/modules/ROOT/pages/getting_started.adoc
+++ b/modules/ROOT/pages/getting_started.adoc
@@ -1,7 +1,7 @@
 = Getting started
-:description: The BCD add-on is provided as a `bonita-continuous-delivery_<version>.zip` archive.
+:description: The BCD add-on is provided as a `bonita-continuous-delivery_{bcdVersion}.zip` archive.
 
-The BCD add-on is provided as a `bonita-continuous-delivery_<version>.zip` archive.
+The BCD add-on is provided as a `bonita-continuous-delivery_{bcdVersion}.zip` archive.
 
 This page describes how to use this archive to start your journey with Bonita Continuous Delivery.
 
@@ -22,39 +22,39 @@ Follow these installation steps on your control host.
 
 
 . Make sure Docker is installed as described in the https://docs.docker.com/engine/installation/[Install Docker] documentation.
-. Extract the `bonita-continuous-delivery_<version>.zip` archive:
+. Extract the `bonita-continuous-delivery_{bcdVersion}.zip` archive:
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
-$ unzip bonita-continuous-delivery_<version>.zip
+$ unzip bonita-continuous-delivery_{bcdVersion}.zip
 ----
 +
-This step creates a `bonita-continuous-delivery_<version>` directory which contains Bonita Continuous Delivery Ansible playbooks and roles.
+This step creates a `bonita-continuous-delivery_{bcdVersion}` directory which contains Bonita Continuous Delivery Ansible playbooks and roles.
 +
 [WARNING]
 ====
 For windows users install in user folder (C:\Users\XXX) (If not, Docker won't have the right to copy the volumes)
 ====
 +
-. Pull the `quay.io/bonitasoft/bcd-controller:<version>` Docker image from secured registry. +
+. Pull the `quay.io/bonitasoft/bcd-controller:{bcdVersion}` Docker image from secured registry. +
 The username corresponds to `bcd_registry_user` and the password corresponds to `bcd_registry_password` described in the xref:scenarios.adoc[Scenario file reference]. Both have been provided by your sales representative.
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
 $ docker login quay.io
 Username: bonitasoft+john_doe_at_acme_com
 Password:
 Login Succeeded
-$ docker pull quay.io/bonitasoft/bcd-controller:<version>
+$ docker pull quay.io/bonitasoft/bcd-controller:{bcdVersion}
 [...]
-Status: Downloaded newer image for quay.io/bonitasoft/bcd-controller:<version>
+Status: Downloaded newer image for quay.io/bonitasoft/bcd-controller:{bcdVersion}
 $ docker logout quay.io
 ----
 +
-The `quay.io/bonitasoft/bcd-controller:<version>` Docker image is now available on the control host.
+The `quay.io/bonitasoft/bcd-controller:{bcdVersion}` Docker image is now available on the control host.
 +
 . Make sure BCD dependencies are present. +
-BCD expects Bonita version-specific dependencies to be present in the `bonita-continuous-delivery_<version>/dependencies` directory. BCD dependencies are provided separately as a `quay.io/bonitasoft/bcd-dependencies:<bonita_version>` Docker data image. +
+BCD expects Bonita version-specific dependencies to be present in the `bonita-continuous-delivery_{bcdVersion}/dependencies` directory. BCD dependencies are provided separately as a `quay.io/bonitasoft/bcd-dependencies:<bonita_version>` Docker data image. +
 Basically, the `/dependencies` volume provided by the `quay.io/bonitasoft/bcd-dependencies` Docker image must be mounted or copied into the `dependencies` directory. For instance, here is how to create a Docker named volume with BCD dependencies from the data image:
 +
 [source,bash]
@@ -76,12 +76,12 @@ The `bcd-dependencies-<bonita_version>` Docker named volume is now available and
 +
 . Start a BCD Controller Docker container on the control host:
 +
-[source,bash]
+[source,bash,subs="attributes"]
 ----
 $ docker run --rm -ti --hostname bcd-controller --name bcd-controller \
     -v <host_path_to_bonita-continuous-delivery_directory>:/home/bonita/bonita-continuous-delivery \
     -v bcd-dependencies-<bonita_version>:/home/bonita/bonita-continuous-delivery/dependencies/<bonita_version> \
-    quay.io/bonitasoft/bcd-controller:<version> /bin/bash
+    quay.io/bonitasoft/bcd-controller:{bcdVersion} /bin/bash
 ----
 +
 This command bind mounts the _bonita-continuous-delivery_ directory and the _bcd-dependencies-<bonita_version>_ volume on the control host into the BCD controller container.
@@ -153,23 +153,23 @@ Here is a complete example of how to install the BCD Controller Docker image.
 
 WARNING: This example uses _fake_ AWS credentials and SSH private key... :-)
 
-Assuming you have a `bonita-continuous-delivery_3.4.2.zip` archive in your `$HOME` directory:
+Assuming you have a `bonita-continuous-delivery_{bcdVersion}.zip` archive in your `$HOME` directory:
 
-[source,bash]
+[source,bash,subs="attributes"]
 ----
 $ cd $HOME
-$ unzip bonita-continuous-delivery_3.4.2.zip
+$ unzip bonita-continuous-delivery_{bcdVersion}.zip
 [...]
 
 $ docker login quay.io
 Username: bonitasoft+john_doe_at_acme_com
 Password:
 Login Succeeded
-$ docker pull quay.io/bonitasoft/bcd-controller:3.4.2
+$ docker pull quay.io/bonitasoft/bcd-controller:{bcdVersion}
 [...]
-Status: Downloaded newer image for quay.io/bonitasoft/bcd-controller:3.4.2
+Status: Downloaded newer image for quay.io/bonitasoft/bcd-controller:{bcdVersion}
 
-$ cd $HOME/bonita-continuous-delivery_3.4.2/dependencies
+$ cd $HOME/bonita-continuous-delivery_{bcdVersion}/dependencies
 
 $ docker run --rm -v bcd-dependencies-7.12.2:/dependencies quay.io/bonitasoft/bcd-dependencies:7.12.2
 [...]
@@ -192,14 +192,14 @@ $ ls -n ~/.ssh/bonita_us-west-2.pem
 
 Finally here is a sample command to start a BCD controller container:
 
-[source,bash]
+[source,bash,subs="attributes"]
 ----
 $ docker run --rm -ti --hostname bcd-controller --name bcd-controller \
         -v ~/bonita-continuous-delivery_3.4.2:/home/bonita/bonita-continuous-delivery \
         -v bcd-dependencies-7.12.2:/home/bonita/bonita-continuous-delivery/dependencies/7.12.2 \
         -v ~/.boto:/home/bonita/.boto \
         -v ~/.ssh/bonita_us-west-2.pem:/home/bonita/.ssh/bonita_us-west-2.pem \
-        bonitasoft/bcd-controller /bin/bash
+        bonitasoft/bcd-controller:{bcdVersion} /bin/bash
 bonita@bcd-controller:~$
 bonita@bcd-controller:~$ cd bonita-continuous-delivery
 bonita@bcd-controller:~/bonita-continuous-delivery$

--- a/modules/ROOT/pages/jenkins_example.adoc
+++ b/modules/ROOT/pages/jenkins_example.adoc
@@ -35,7 +35,7 @@ BCD must be installed on the Docker host which acts here as a *control host*. Th
 The Docker host should now have:
 
 * the `bonitasoft/bcd-controller` Docker image loaded
-* the `bonita-continuous-delivery_<version>` directory present
+* the `bonita-continuous-delivery_{bcdVersion}` directory present
 * optionally, the security files for BCD provisioning (SSH key files, AWS credentials)
 
 === Configure Jenkins master
@@ -93,11 +93,12 @@ Click on *Add Docker template* to add a Docker template in the Docker cloud and 
 * *Labels*: `bcd`
 * *Enabled*: `[checked]`
 * *Name*: `bcd`
-* *Docker Image*: `quay.io/bonitasoft/bcd-controller:3.4.1` (where 3.0.1 is the version of BCD to use)
+* *Docker Image*: `quay.io/bonitasoft/bcd-controller:{bcdVersion}` (where {bcdVersion} is the version of BCD to use)
 * *Volumes*:
 +
+[source,bash,subs="attributes"]
 ----
-/home/dockeruser/bonita-continuous-delivery_3.0.1:/home/bonita/bonita-continuous-delivery
+/home/dockeruser/bonita-continuous-delivery_{bcdVersion}:/home/bonita/bonita-continuous-delivery
 /home/dockeruser/.ssh:/home/bonita/.ssh
 bcd-dependencies-7.11.0:/home/bonita/bonita-continuous-delivery/dependencies/7.11.0
 ----
@@ -168,7 +169,7 @@ This scripted pipeline can also be used in a https://jenkins.io/doc/book/pipelin
 
 == Standalone example
 
-The `bonita-continuous-delivery_<version>.zip` archive also provides a `jenkins-example` directory which contains a minimal working example of a Continuous Delivery platform with Jenkins and BCD. This example will start a pre-configured Jenkins server with a BCD-aware Jenkins slave and ready-to-use Jenkins jobs.
+The `bonita-continuous-delivery_{bcdVersion}.zip` archive also provides a `jenkins-example` directory which contains a minimal working example of a Continuous Delivery platform with Jenkins and BCD. This example will start a pre-configured Jenkins server with a BCD-aware Jenkins slave and ready-to-use Jenkins jobs.
 
 It is provided as a https://docs.docker.com/compose/[Docker Compose] project.
 

--- a/modules/ROOT/pages/troubleshooting_guide.adoc
+++ b/modules/ROOT/pages/troubleshooting_guide.adoc
@@ -193,14 +193,14 @@ By default, the path of the log is `/var/log/ansible.log` in your Docker contain
 
 If you want to persist the log, you can add a *_volume_* in when you run `docker run` command like
 
-[source,bash]
+[source,bash,subs="attributes"]
 ----
 $ docker run --rm -t -i --name bcd-controller \
     -v <host_path_to_.boto>:/home/bonita/.boto \
     -v <host_path_to_bonita-continuous-delivery_folder>:/home/bonita/bonita-continuous-delivery \
     -v <host_path_to_ssh_private_key>:/home/bonita/.ssh/<ssh_private_key> \
     -v <host_path_to_your_ansible_log>:/var/log/ansible.log \
-    quay.io/bonitasoft/bcd-controller /bin/bash
+    quay.io/bonitasoft/bcd-controller:{bcdVersion} /bin/bash
 ----
 
 == Files owned by another user in the workspace (Linux users only)

--- a/modules/ROOT/pages/upgrade_bcd.adoc
+++ b/modules/ROOT/pages/upgrade_bcd.adoc
@@ -48,15 +48,15 @@ $ cp -r bonita-continuous-delivery_2.1.0/terraform/your_stack_name bonita-contin
 
 ==== BCD controller
 
-As is described in the "Installation guide" from the xref:getting_started.adoc[Getting started] you will need to load the last version of `bcd-controller_<version>.tar.zip` Docker image. +
+As is described in the "Installation guide" from the xref:getting_started.adoc[Getting started] you will need to load the last version of `bcd-controller_{bcdVersion}.tar.zip` Docker image. +
 You can also directly use the secured Docker registry to retrieve the latest image.
 
-[source,bash,subs="+macros"]
+[source,bash,subs="+macros,attributes"]
 ----
 $ docker login quay.io
 Username: bonitasoft+john_doe_at_acme_com
 Password:
-$ docker pull quay.io/bonitasoft/bcd-controller
+$ docker pull quay.io/bonitasoft/bcd-controller:{bcdVersion}
 ----
 
 The username corresponds to `bcd_registry_user` and the password corresponds to `bcd_registry_password` described in the xref:scenarios.adoc[Scenario file reference]. Both have been provided by your sales representative.


### PR DESCRIPTION
* now that controller version is mandatory, it needs to be everywhere in the documentation