### PR TITLE
fix(deps): fix release note about removals

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -39,5 +39,5 @@ jobs:
           failOnError: true
           teardown: 'true'
           build: |
-            ./build-preview.bash --use-multi-repositories --component-with-branches bonita:"${{ env.BONITA_BRANCH }}" --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.BRANCH_NAME }}" --pr "${{ env.PR_NUMBER }}" --site-url "${{ env.PREVIEW_URL }}"
+            ./build-preview.bash --use-multi-repositories --component-with-branches bonita:"${{ env.BONITA_BRANCH }}" --component-with-branches cloud:"master" --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.BRANCH_NAME }}" --pr "${{ env.PR_NUMBER }}" --site-url "${{ env.PREVIEW_URL }}"
             ls -lh build/site

--- a/modules/ROOT/pages/release_notes.adoc
+++ b/modules/ROOT/pages/release_notes.adoc
@@ -5,8 +5,19 @@
 === Breaking changes
 
 * As announced in version 3.4.4, `stack` and `license` commands are now removed from the CLI. +
- As a result, scenario files must be updated since a lot parameters are now obsolete and a few remains mandatory (see xref:scenarios.adoc[]) +
-If you were using ansible `inventories/stack ids` to perform deployment (in your CI pipelines), you have to use the `url` of the targeted bonita instance instead. Ansible inventory was related to the `bcd stack` part and is now removed.
+ As a result, scenario files must be updated since a lot of parameters are now obsolete and a few remains mandatory (see xref:scenarios.adoc[])
+* For the same reason, `openssh-client` package was removed from the docker controller image. +
+You can re-add this package if needed by building a custom image of the controller.
+
+.Sample custom BCD Controller with ssh client
+[source,docker]
+----
+FROM quay.io/bonitasoft/bcd-controller:{bcdVersion}
+
+USER root
+RUN apt update && apt install -y openssh-client
+USER bonita
+----
 
 === Technology upgrade
 
@@ -17,6 +28,15 @@ If you were using ansible `inventories/stack ids` to perform deployment (in your
 
 * chore(deps): bump urllib3 from 1.26.4 to 1.26.5 in bcd-cli
 * feat(bonita): update support for bonita version 7.13.0
+
+=== Removals
+
+==== System packages
+
+* openssh-client
+* ttf-dejavu
+* gcc
+* g++
 
 == What's new in 3.4.5
 


### PR DESCRIPTION
SSH removal was forgotten from release notes
Mention also other removals  : ttf-dejavu, gcc and g++

Fixes [BCD-558](https://bonitasoft.atlassian.net/browse/BCD-558)