### PR TITLE
ci: use shared actions to build/publish pr preview

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -2,42 +2,28 @@ name: Build PR preview
 
 on:
   pull_request:
-    # To manage 'surge-preview' action teardown, add default event types + closed event type
-    types: [opened, synchronize, reopened, closed]
     paths:
-      - 'modules/ROOT/**'
+      - 'modules/**'
       - 'antora.yml'
       - '.github/workflows/build-pr-preview.yml'
+
 jobs:
   build_preview:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       COMPONENT_NAME: bcd
-      # Except if you want to test in progress work that your content depends on, keep it set to master
-      DOC_SITE_BRANCH: master
+      COMPONENT_BRANCH_NAME: ${{ github.head_ref }}
+      COMPONENT_VERSION: ${{ github.base_ref }} # The base_ref or target branch of the pull request in a workflow run.
+      # Required to pass xref validation
       BONITA_BRANCH: '2021.1'
-      PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
-      - name: Get documentation site source code
-        if: github.event.action != 'closed'
-        run: |
-          # Remove existing .git directory
-          rm -rf *
-          git clone --depth 1 --single-branch --branch ${DOC_SITE_BRANCH} https://github.com/bonitasoft/bonitasoft.github.io.git .
-      - name: Compute environment variables
-        run: |
-          echo "BRANCH_NAME=$(echo ${GITHUB_HEAD_REF#refs/heads/})" >> $GITHUB_ENV
-          # the surge-preview action generates https://{{repository.owner}}-{{repository.name}}-{{job.name}}-pr-{{pr.number}}.surge.sh
-          repo_owner_and_name=$(echo "${{github.repository}}" | sed 's/\//-/g')
-          echo PREVIEW_URL=https://$repo_owner_and_name-"${{github.job}}"-pr-$PR_NUMBER.surge.sh >> $GITHUB_ENV
-      - name: Publish preview
-        uses: afc163/surge-preview@v1
+      - name: Build PR preview
+        uses: bonitasoft/bonita-documentation-site/.github/actions/build-pr-site/@master
         with:
-          surge_token: ${{ secrets.SURGE_TOKEN_DOC }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          dist: build/site
-          failOnError: true
-          teardown: 'true'
-          build: |
-            ./build-preview.bash --use-multi-repositories --component-with-branches bonita:"${{ env.BONITA_BRANCH }}" --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.BRANCH_NAME }}" --pr "${{ env.PR_NUMBER }}" --site-url "${{ env.PREVIEW_URL }}"
-            ls -lh build/site
+          # '>' Replace newlines with spaces (folded)
+          # '-' No newline at end (strip)
+          build-preview-command: >-
+            ./build-preview.bash --use-multi-repositories
+            --start-page "${{ env.COMPONENT_VERSION }}"@"${{ env.COMPONENT_NAME }}"::index.adoc
+            --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.COMPONENT_BRANCH_NAME }}"
+            --component-with-branches bonita:"${{ env.BONITA_BRANCH }}"

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build_preview:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     env:
       COMPONENT_NAME: bcd
       COMPONENT_BRANCH_NAME: ${{ github.head_ref }}

--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build_preview:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       COMPONENT_NAME: bcd
       COMPONENT_BRANCH_NAME: ${{ github.head_ref }}

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   build_preview:
     runs-on: ubuntu-22.04
+    INVALID
     permissions:
       pull-requests: write # surge-preview write PR comments
     steps:

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -1,0 +1,22 @@
+name: Publish PR preview
+
+on:
+  pull_request:
+    # To manage 'surge-preview' action teardown, add default event types + closed event type
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - 'modules/**'
+      - 'antora.yml'
+      - '.github/workflows/publish-pr-preview.yml'
+jobs:
+  build_preview:
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write # surge-preview write PR comments
+    steps:
+      - name: Build and publish pr preview
+        uses: bonitasoft/bonita-documentation-site/.github/actions/build-and-publish-pr-preview/@master
+        with:
+          surge-token: ${{ secrets.SURGE_TOKEN_DOC }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          component-name: bcd

--- a/.github/workflows/publish-pr-preview.yml
+++ b/.github/workflows/publish-pr-preview.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   build_preview:
     runs-on: ubuntu-22.04
-    INVALID
     permissions:
       pull-requests: write # surge-preview write PR comments
     steps:

--- a/README.adoc
+++ b/README.adoc
@@ -1,13 +1,13 @@
 = Bonita Continuous Delivery documentation resources
 
-This repository contains the sources of the https://documentation.bonitasoft.com/bcd[Bonita Continuous Delivery documentation site]. It uses https://docs.asciidoctor.org/asciidoc/latest/[Asciidoc] format for
+This repository contains the sources of the https://documentation.bonitasoft.com/bcd[Bonita Continuous Delivery documentation site]. It uses https://docs.asciidoctor.org/asciidoc/latest/[AsciiDoc] format for
 the documentation content.
 
 
 == Content writing guidelines
 
 See https://github.com/bonitasoft/bonita-documentation-site/blob/master/docs/content/CONTRIBUTING.adoc[Bonita documentation content writing guidelines] for
-recommendations about writing Asciidoc pages the Bonita-way.
+recommendations about writing AsciiDoc pages the Bonita-way.
 
 
 == Providing feedbacks about Bonita product


### PR DESCRIPTION
Introduce a workflow that is in charge of checking the xref validity. The workflow that publish the preview is simplified and build faster: it only builds the current branch and skip the xref validation.
Use the actions provided by the `bonita-documentation-site` repository to simplify the workflows.

covers https://github.com/bonitasoft/bonita-documentation-site/issues/418