### PR TITLE
ci: check 3.5 preview

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -16,7 +16,7 @@ jobs:
       # Except if you want to test in progress work that your content depends on, keep it set to master
       DOC_SITE_BRANCH: master
       BONITA_BRANCH: '2021.2'
-      # TODO: cloud seems needed
+      # TODO: cloud seems needed?
       PR_NUMBER: ${{ github.event.pull_request.number }}
     steps:
       - name: Get documentation site source code


### PR DESCRIPTION
**NOT FOR MERGE**
The 3.5 branch needs cloud that requires cloud for xref validation

```
[09:45:54.747] ERROR (asciidoctor): target of xref not found: test-toolkit:ROOT:process-testing-overview.adoc
    file: modules/ROOT/pages/Continuous_Delivery_Test_a_Living_Application.adoc:10
    source: https://github.com/bonitasoft/bonita-cloud-doc.git (branch: master)
[09:45:54.748] ERROR (asciidoctor): target of xref not found: test-toolkit:ROOT:quick-start.adoc#quick-start-test
    file: modules/ROOT/pages/Continuous_Delivery_Test_a_Living_Application.adoc:14
```
Will be fixed after merge of 3.4 into 3.5. See #196