### PR TITLE
ci: add workflows to check PR title and contributions content

### DIFF
--- a/.github/workflows/commit-checks.yml
+++ b/.github/workflows/commit-checks.yml
@@ -1,0 +1,15 @@
+name: Commit checks
+
+on:
+  pull_request_target:
+    # trigger when the PR title changes
+    types: [opened, edited, reopened]
+
+jobs:
+  pr-title:
+    runs-on: ubuntu-22.04
+    permissions:
+      pull-requests: write # post comments when the PR title doesn't match the "Conventional Commits" rules
+    steps:
+      - name: Check Pull Request title
+        uses: bonitasoft/actions/packages/pr-title-conventional-commits@v2

--- a/.github/workflows/contribution-checks.yml
+++ b/.github/workflows/contribution-checks.yml
@@ -1,0 +1,16 @@
+name: Contribution checks
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  pr-content-check:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check PR content
+        uses: bonitasoft/actions/packages/pr-diff-checker@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          diffDoesNotContain: '["https://documentation.bonitasoft.com/", "Bonita BPM"]'
+          extensionsToCheck: '[".adoc"]'


### PR DESCRIPTION
Use the same workflows as in other documentation content repositories.

### Status

It has been successfully tested in https://github.com/bonitasoft/bonita-apps-manager-doc/pull/3