### PR TITLE
fix(escaping): fix html rendering of some code sample and update antora.yaml

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -16,6 +16,7 @@ jobs:
       COMPONENT_VERSION: ${{ github.base_ref }} # The base_ref or target branch of the pull request in a workflow run.
       # Required to pass xref validation
       BONITA_BRANCH: '2022.1'
+      BONITA_BRANCH_FOR_BONITA: '2021.1'
       CLOUD_BRANCH: 'master'
       # Needed to build the 'cloud' doc
       TOOLKIT_BRANCH: '1.0'
@@ -30,7 +31,7 @@ jobs:
             ./build-preview.bash --use-multi-repositories
             --start-page "${{ env.COMPONENT_VERSION }}"@"${{ env.COMPONENT_NAME }}"::index.adoc
             --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.COMPONENT_BRANCH_NAME }}"
-            --component-with-branches bonita:"${{ env.BONITA_BRANCH }},${{ env.BONITA_BRANCH_FOR_TOOLKIT }}"
+            --component-with-branches bonita:"${{ env.BONITA_BRANCH }},${{ env.BONITA_BRANCH_FOR_TOOLKIT }},${{env.BONITA_BRANCH_FOR_BONITA}}"
             --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"
             --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}"
 

--- a/antora.yml
+++ b/antora.yml
@@ -3,8 +3,8 @@ title: Continuous Delivery
 version: 3.6
 asciidoc:
   attributes:
-    bcdVersion: '3.6.0' # latest available maintenance version
-    bonitaDocVersion: '2022.1'
+    bcdVersion: '3.6.1' # latest available maintenance version
+    bonitaDocVersion: '2022.2'
     testToolkitVersion: '1.0'
     # General site configuration
     page-editable: true

--- a/modules/ROOT/pages/bcd_controller.adoc
+++ b/modules/ROOT/pages/bcd_controller.adoc
@@ -42,8 +42,8 @@ The first method to start a BCD Controller Docker container on the control host 
 [source,bash,subs="attributes"]
 ----
 $ docker run --rm -t -i --name bcd-controller \
-    -v bcd-dependencies-<bonita_version>:/home/bonita/bonita-continuous-delivery/dependencies/<bonita_version>  \
-    -v <host_path_to_bonita-continuous-delivery_folder>:/home/bonita/bonita-continuous-delivery \
+    -v bcd-dependencies-&lt;bonita_version>:/home/bonita/bonita-continuous-delivery/dependencies/&lt;bonita_version>  \
+    -v &lt;host_path_to_bonita-continuous-delivery_folder>:/home/bonita/bonita-continuous-delivery \
     quay.io/bonitasoft/bcd-controller:{bcdVersion} /bin/bash
 ----
 

--- a/modules/ROOT/pages/getting_started.adoc
+++ b/modules/ROOT/pages/getting_started.adoc
@@ -79,8 +79,8 @@ The `bcd-dependencies-<bonita_version>` Docker named volume is now available and
 [source,bash,subs="attributes"]
 ----
 $ docker run --rm -ti --hostname bcd-controller --name bcd-controller \
-    -v <host_path_to_bonita-continuous-delivery_directory>:/home/bonita/bonita-continuous-delivery \
-    -v bcd-dependencies-<bonita_version>:/home/bonita/bonita-continuous-delivery/dependencies/<bonita_version> \
+    -v &lt;host_path_to_bonita-continuous-delivery_directory>:/home/bonita/bonita-continuous-delivery \
+    -v bcd-dependencies-&lt;bonita_version>:/home/bonita/bonita-continuous-delivery/dependencies/&lt;bonita_version> \
     quay.io/bonitasoft/bcd-controller:{bcdVersion} /bin/bash
 ----
 +

--- a/modules/ROOT/pages/troubleshooting_guide.adoc
+++ b/modules/ROOT/pages/troubleshooting_guide.adoc
@@ -113,8 +113,8 @@ If you want to persist the log, you can add a *_volume_* in when you run `docker
 [source,bash,subs="attributes"]
 ----
 $ docker run --rm -t -i --name bcd-controller \
-    -v <host_path_to_bonita-continuous-delivery_folder>:/home/bonita/bonita-continuous-delivery \
-    -v <host_path_to_your_ansible_log>:/var/log/ansible.log \
+    -v &lt;host_path_to_bonita-continuous-delivery_folder>:/home/bonita/bonita-continuous-delivery \
+    -v &lt;host_path_to_your_ansible_log>:/var/log/ansible.log \
     quay.io/bonitasoft/bcd-controller:{bcdVersion} /bin/bash
 ----
 


### PR DESCRIPTION
- changed for html entity because escaping didn't work for `<` term
- updated antora.yaml to point latest versions of bcd and bonita