### PR TITLE
ci: simplify xref validation

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -8,30 +8,20 @@ on:
       - '.github/workflows/build-pr-preview.yml'
 
 jobs:
-  build_preview:
+  validate_xref:
     runs-on: ubuntu-22.04
     env:
       COMPONENT_NAME: bcd
       COMPONENT_BRANCH_NAME: ${{ github.head_ref }}
       COMPONENT_VERSION: ${{ github.base_ref }} # The base_ref or target branch of the pull request in a workflow run.
-      # Required to pass xref validation
-      BONITA_BRANCH: '2022.1'
-      BONITA_BRANCH_FOR_BONITA: '2021.1'
-      CLOUD_BRANCH: 'master'
-      # Needed to build the 'cloud' doc
-      TOOLKIT_BRANCH: '1.0'
-      BONITA_BRANCH_FOR_TOOLKIT: '2022.2'
     steps:
-      - name: Build PR preview
+      - name: Validate xref
         uses: bonitasoft/bonita-documentation-site/.github/actions/build-pr-site/@master
         with:
           # '>' Replace newlines with spaces (folded)
           # '-' No newline at end (strip)
           build-preview-command: >-
-            ./build-preview.bash --use-multi-repositories
-            --start-page "${{ env.COMPONENT_VERSION }}"@"${{ env.COMPONENT_NAME }}"::index.adoc
-            --component-with-branches "${{ env.COMPONENT_NAME }}":"${{ env.COMPONENT_BRANCH_NAME }}"
-            --component-with-branches bonita:"${{ env.BONITA_BRANCH }},${{ env.BONITA_BRANCH_FOR_TOOLKIT }},${{env.BONITA_BRANCH_FOR_BONITA}}"
-            --component-with-branches cloud:"${{ env.CLOUD_BRANCH }}"
-            --component-with-branches test-toolkit:"${{ env.TOOLKIT_BRANCH }}"
+            ./build-preview.bash
+            --component "${{ env.COMPONENT_NAME }}"
+            --branch "${{ env.COMPONENT_BRANCH_NAME }}"
 


### PR DESCRIPTION
Use the new Antora Atlas feature. There is no more need to reference all dependent components/versions to validate xrefs.

covers https://github.com/bonitasoft/bonita-documentation-site/issues/583