### PR TITLE
ci: fail validation on asciidoctor warnings

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -24,4 +24,4 @@ jobs:
             ./build-preview.bash
             --component "${{ env.COMPONENT_NAME }}"
             --branch "${{ env.COMPONENT_BRANCH_NAME }}"
-
+          fail-on-warning: true

--- a/.github/workflows/contribution-checks.yml
+++ b/.github/workflows/contribution-checks.yml
@@ -12,5 +12,5 @@ jobs:
         uses: bonitasoft/actions/packages/pr-diff-checker@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          diffDoesNotContain: '["https://documentation.bonitasoft.com/", "Bonita BPM"]'
+          diffDoesNotContain: '["https://documentation.bonitasoft.com/", "Bonita BPM", "link:https", "link:http", "xref:https", "xref:http", "xref:_", "xref:#"]'
           extensionsToCheck: '[".adoc"]'

--- a/modules/ROOT/pages/bcd_controller.adoc
+++ b/modules/ROOT/pages/bcd_controller.adoc
@@ -108,8 +108,8 @@ ARG BONITA_GID
 
 USER root
 
-RUN groupmod -g ${BONITA_GID} bonita && \
-    usermod -u ${BONITA_UID} -g ${BONITA_GID} bonita && \
+RUN groupmod -g $\{BONITA_GID} bonita && \
+    usermod -u $\{BONITA_UID} -g $\{BONITA_GID} bonita && \
     chown bonita:bonita /var/log/ansible.log
 
 USER bonita

--- a/modules/ROOT/pages/livingapp_build_and_deploy_without_docker.adoc
+++ b/modules/ROOT/pages/livingapp_build_and_deploy_without_docker.adoc
@@ -15,7 +15,7 @@ This chapter assumes that:
 
 == How to build the living application
 
-To build a Living application, you'll need both the `bonita-la-builder-${BONITA_VERSION}-exec.jar` CLI application, and the `bonita-sp-${BONITA_VERSION}-maven-repository.zip` maven dependency package.
+To build a Living application, you'll need both the `+bonita-la-builder-${BONITA_VERSION}-exec.jar+` CLI application, and the `+bonita-sp-${BONITA_VERSION}-maven-repository.zip+` maven dependency package.
 
 === Extract the LA Builder CLI
 
@@ -140,7 +140,7 @@ Usage: java -jar bonita-la-builder-7.12.2-exec.jar [command] [command options]
 
 == How to deploy the living application
 
-To deploy a Living application, you'll need the `bonita-la-deployer-${DEPLOYER_VERSION}.jar` CLI application.
+To deploy a Living application, you'll need the `+bonita-la-deployer-${DEPLOYER_VERSION}.jar+` CLI application.
 
 === Extract the LA Deployer CLI
 


### PR DESCRIPTION
Fix some warnings (wrong attribute expansion).
The workflow that checks changes now prohibits certain erroneous forms of xref and link, to prevent new errors from being added.