### PR TITLE
ci: make workflows better work for PR created from forked repo

### DIFF
--- a/.github/workflows/build-pr-preview.yml
+++ b/.github/workflows/build-pr-preview.yml
@@ -6,22 +6,12 @@ on:
       - 'modules/**'
       - 'antora.yml'
       - '.github/workflows/build-pr-preview.yml'
-
 jobs:
   validate_xref:
     runs-on: ubuntu-22.04
-    env:
-      COMPONENT_NAME: bcd
-      COMPONENT_BRANCH_NAME: ${{ github.head_ref }}
-      COMPONENT_VERSION: ${{ github.base_ref }} # The base_ref or target branch of the pull request in a workflow run.
     steps:
       - name: Validate xref
         uses: bonitasoft/bonita-documentation-site/.github/actions/build-pr-site/@master
         with:
-          # '>' Replace newlines with spaces (folded)
-          # '-' No newline at end (strip)
-          build-preview-command: >-
-            ./build-preview.bash
-            --component "${{ env.COMPONENT_NAME }}"
-            --branch "${{ env.COMPONENT_BRANCH_NAME }}"
+          component-name: bcd
           fail-on-warning: true

--- a/.github/workflows/contribution-checks.yml
+++ b/.github/workflows/contribution-checks.yml
@@ -1,7 +1,7 @@
 name: Contribution checks
 
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
   check_antora_content_guidelines:


### PR DESCRIPTION
"contribution checks"
The workflow now runs on `pull_request_target` events.
There are no security issues here. Checks are made only on the updated PR file without doing any tool installation, cache update or branch check. Only the GitHub API is used.
Using this event allows you to create a PR comment when the PR is created from a forked repository.

"build preview" and "references validation" workflows.
The content of the branch of the fork is now correctly used. Previously, the branch of the fork wasn't found by Antora, so the content of the generated site was empty.

### Notes

Covers https://github.com/bonitasoft/bonita-documentation-site/issues/402
Covers https://github.com/bonitasoft/bonita-documentation-site/issues/685