### PR TITLE
ci: Skip page-filename step on contribution check

### DIFF
--- a/.github/workflows/contribution-checks.yml
+++ b/.github/workflows/contribution-checks.yml
@@ -8,3 +8,5 @@ jobs:
     permissions:
       pull-requests: write # "pr-antora-content-guidelines-checker" write PR comments when the PR doesn't match the "Guidelines"
     uses: bonitasoft/bonita-documentation-site/.github/workflows/_reusable_pr-antora-content-guidelines-checker.yml@master
+    with:
+      steps-to-skip: page-filename


### PR DESCRIPTION
* all Filename are actually didn't follow the convention And this documentation content is not updated.
That's why we want to skip the page-filename step on the contribution check.

Cover bonitasoft/bonita-documentation-site#589